### PR TITLE
move playground to before user middlewares

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -157,6 +157,17 @@ export class GraphQLServer {
       app.post(this.options.endpoint, apolloUploadExpress())
     }
 
+    if (this.options.playground) {
+      const playgroundOptions = subscriptionServerOptions
+        ? {
+            endpoint: this.options.endpoint,
+            subscriptionsEndpoint: subscriptionServerOptions.path,
+          }
+        : { endpoint: this.options.endpoint }
+
+      app.get(this.options.playground, expressPlayground(playgroundOptions))
+    }
+
     // All middlewares added before start() was called are applied to
     // the express application here, in the order they were provided
     // (following Queue pattern)
@@ -213,17 +224,6 @@ export class GraphQLServer {
         }
       }),
     )
-
-    if (this.options.playground) {
-      const playgroundOptions = subscriptionServerOptions
-        ? {
-            endpoint: this.options.endpoint,
-            subscriptionsEndpoint: subscriptionServerOptions.path,
-          }
-        : { endpoint: this.options.endpoint }
-
-      app.get(this.options.playground, expressPlayground(playgroundOptions))
-    }
 
     if (!this.executableSchema) {
       throw new Error('No schema defined')


### PR DESCRIPTION
playground is a feature that is usually disabled in production (so in general I don't expect user middlewares to look for playground calls and do things like logging).  when its turned on, we should intercept it before the user middlewares.  This avoids the problems that comes when dealing with default routes having to blacklist the playground uri.