### PR TITLE
The deduplicator now accepts a query param

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ The `options` object has the following fields:
 | `uploads`       | [UploadOptions](/src/types.ts#L39-L43) or `false` or `undefined` | `null`          | Provides information about upload limits; the object can have any combination of the following three keys: `maxFieldSize`, `maxFileSize`, `maxFiles`; each of these have values of type Number; setting to `false` disables file uploading                                                                                   |
 | `https`         | [HttpsOptions](/src/types.ts#L62-L65) or `undefined`             | `undefined`     | Enables HTTPS support with a key/cert
 | `getEndpoint`  | String or Boolean |  `false`  | Adds a graphql HTTP GET endpoint to your server (defaults to `endpoint` if `true`).  Used for leveraging CDN level caching. |
-| `deduplicator` | Boolean | `true` | Enables [graphql-deduplicator](https://github.com/gajus/graphql-deduplicator). Once enabled sending the header `X-GraphQL-Deduplicate` will deduplicate the data.  |
+| `deduplicator` | Boolean | `true` | Enables [graphql-deduplicator](https://github.com/gajus/graphql-deduplicator). Once enabled sending the query param `?deduplicate` will deduplicate the data.  |
 | `bodyParserOptions` | BodyParserJSONOptions | [BodyParserJSONOptions Defaults](https://github.com/expressjs/body-parser#bodyparserjsonoptions) | Allows pass through of [body-parser options](https://github.com/expressjs/body-parser#bodyparserjsonoptions)  |
 
 Additionally, the `options` object exposes these `apollo-server` options:

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ The `options` object has the following fields:
 | `uploads`       | [UploadOptions](/src/types.ts#L39-L43) or `false` or `undefined` | `null`          | Provides information about upload limits; the object can have any combination of the following three keys: `maxFieldSize`, `maxFileSize`, `maxFiles`; each of these have values of type Number; setting to `false` disables file uploading                                                                                   |
 | `https`         | [HttpsOptions](/src/types.ts#L62-L65) or `undefined`             | `undefined`     | Enables HTTPS support with a key/cert
 | `getEndpoint`  | String or Boolean |  `false`  | Adds a graphql HTTP GET endpoint to your server (defaults to `endpoint` if `true`).  Used for leveraging CDN level caching. |
-| `deduplicator` | Boolean | `true` | Enables [graphql-deduplicator](https://github.com/gajus/graphql-deduplicator). Once enabled sending the query param `?deduplicate` will deduplicate the data.  |
+| `deduplicator` | Boolean | `true` | Enables [graphql-deduplicator](https://github.com/gajus/graphql-deduplicator). Once enabled, adding `?deduplicate` to the endpoint URL will deduplicate the data.  |
 | `bodyParserOptions` | BodyParserJSONOptions | [BodyParserJSONOptions Defaults](https://github.com/expressjs/body-parser#bodyparserjsonoptions) | Allows pass through of [body-parser options](https://github.com/expressjs/body-parser#bodyparserjsonoptions)  |
 
 Additionally, the `options` object exposes these `apollo-server` options:

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -4,11 +4,11 @@ import { GraphQLServer, Options } from './index'
 import { promisify } from 'util'
 import * as request from 'request-promise-native'
 
-async function startServer(
-  t: TestContext & Context<any>,
-  options?: Options
-) {
-  const randomId = () => Math.random().toString(36).substr(2, 5)
+async function startServer(t: TestContext & Context<any>, options?: Options) {
+  const randomId = () =>
+    Math.random()
+      .toString(36)
+      .substr(2, 5)
 
   const typeDefs = `
     type Author {
@@ -33,18 +33,18 @@ async function startServer(
     __typename: 'Author',
     id: randomId(),
     name: 'Jhon',
-    lastName: 'Doe'
+    lastName: 'Doe',
   }
   const book = {
     __typename: 'Book',
     id: randomId(),
     name: 'Awesome',
-    author
+    author,
   }
   const resolvers = {
     Query: {
       hello: (_, { name }) => `Hello ${name || 'World'}`,
-      books: () => Array(5).fill(book)
+      books: () => Array(5).fill(book),
     },
   }
 
@@ -70,7 +70,7 @@ test.afterEach.always('stop graphql servers', async t => {
 
   if (httpServers && httpServers.length) {
     await Promise.all(
-      httpServers.map(server => promisify(server.close).call(server))
+      httpServers.map(server => promisify(server.close).call(server)),
     )
   }
 })
@@ -99,7 +99,10 @@ test('works with simple hello world server', async t => {
 })
 
 test('Response data can be deduplicated with graphql-deduplicator', async t => {
-  const { uri, data: { book } } = await startServer(t)
+  const {
+    uri,
+    data: { book },
+  } = await startServer(t)
 
   const query = `
     query {
@@ -125,19 +128,26 @@ test('Response data can be deduplicated with graphql-deduplicator', async t => {
   }).promise()
 
   const deduplicated = await request({
+    uri: uri + '?deduplicate',
+    method: 'POST',
+    json: true,
+    body: { query },
+  }).promise()
+
+  const deduplicatedWithHeader = await request({
     uri,
     method: 'POST',
     json: true,
     body: { query },
     headers: {
-      'X-GraphQL-Deduplicate': true
-    }
+      'X-GraphQL-Deduplicate': true,
+    },
   }).promise()
 
   t.deepEqual(body, {
     data: {
-      books: Array(5).fill(book)
-    }
+      books: Array(5).fill(book),
+    },
   })
 
   t.deepEqual(deduplicated, {
@@ -146,18 +156,23 @@ test('Response data can be deduplicated with graphql-deduplicator', async t => {
         book,
         ...Array(4).fill({
           __typename: book.__typename,
-          id: book.id
-        })
-      ]
-    }
+          id: book.id,
+        }),
+      ],
+    },
   })
+
+  t.deepEqual(deduplicated, deduplicatedWithHeader)
 
   t.deepEqual(body.data, inflate(deduplicated.data))
 })
 
-test('graphql-deduplicated can be completely disabled', async t => {
-  const { uri, data: { book } } = await startServer(t, {
-    deduplicator: false
+test('graphql-deduplicator can be completely disabled', async t => {
+  const {
+    uri,
+    data: { book },
+  } = await startServer(t, {
+    deduplicator: false,
   })
 
   const query = `
@@ -177,18 +192,15 @@ test('graphql-deduplicated can be completely disabled', async t => {
   `
 
   const body = await request({
-    uri,
+    uri: uri + '?deduplicate',
     method: 'POST',
     json: true,
     body: { query },
-    headers: {
-      'X-GraphQL-Deduplicate': true
-    }
   }).promise()
 
   t.deepEqual(body, {
     data: {
-      books: Array(5).fill(book)
-    }
+      books: Array(5).fill(book),
+    },
   })
 })

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -134,6 +134,7 @@ test('Response data can be deduplicated with graphql-deduplicator', async t => {
     body: { query },
   }).promise()
 
+  // The use of a header is deprecated but should work
   const deduplicatedWithHeader = await request({
     uri,
     method: 'POST',

--- a/src/index.ts
+++ b/src/index.ts
@@ -183,10 +183,8 @@ export class GraphQLServer {
         return this.options.formatResponse
       }
       return (response, ...args) => {
-        const truthyValues = ['', '1', 'true']
-
         if (
-          (truthyValues.includes(req.query.deduplicate) ||
+          (isTrulyQueryParam(req.query.deduplicate) ||
             req.get('X-GraphQL-Deduplicate')) &&
           response.data &&
           !response.data.__schema
@@ -458,4 +456,13 @@ function mergeTypeDefs(typeDefs: ITypeDefinitions): string {
 
 function isDocumentNode(node: any): node is DocumentNode {
   return node.kind === 'Document'
+}
+
+/**
+ * Normalises GET parameter values into a boolean.
+ * Returns true in the following cases:
+ * ?value ?value= ?value=1 ?value=true
+ */
+function isTrulyQueryParam(value: string) {
+  return value === '' || value === '1' || value === 'true'
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -119,11 +119,10 @@ export class GraphQLServer {
       if (mocks) {
         addMockFunctionsToSchema({
           schema: this.executableSchema,
-          mocks: typeof mocks === "object" ? mocks : undefined,
+          mocks: typeof mocks === 'object' ? mocks : undefined,
           preserveResolvers: false,
         })
       }
-
     }
 
     if (props.middlewares) {
@@ -184,9 +183,11 @@ export class GraphQLServer {
         return this.options.formatResponse
       }
       return (response, ...args) => {
+        const truthyValues = ['', '1', 'true']
+
         if (
-          (req.get('X-GraphQL-Deduplicate') ||
-            req.query.deduplicate !== undefined) &&
+          (truthyValues.includes(req.query.deduplicate) ||
+            req.get('X-GraphQL-Deduplicate')) &&
           response.data &&
           !response.data.__schema
         ) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -175,7 +175,8 @@ export class GraphQLServer {
       }
       return (response, ...args) => {
         if (
-          req.get('X-GraphQL-Deduplicate') &&
+          (req.get('X-GraphQL-Deduplicate') ||
+            req.query.deduplicate !== undefined) &&
           response.data &&
           !response.data.__schema
         ) {
@@ -195,7 +196,10 @@ export class GraphQLServer {
       app.use(cors())
     }
 
-    app.post(this.options.endpoint, bodyParser.graphql(this.options.bodyParserOptions))
+    app.post(
+      this.options.endpoint,
+      bodyParser.graphql(this.options.bodyParserOptions),
+    )
 
     if (this.options.uploads) {
       app.post(this.options.endpoint, apolloUploadExpress(this.options.uploads))

--- a/src/types.ts
+++ b/src/types.ts
@@ -137,10 +137,10 @@ export interface LambdaOptions extends ApolloServerOptions {
 }
 
 export interface BodyParserJSONOptions {
-  limit?: number | string,
-  inflate?: boolean,
-  reviver?: any,
-  strict?: boolean,
-  type?: string,
-  verify?: any,
+  limit?: number | string
+  inflate?: boolean
+  reviver?: any
+  strict?: boolean
+  type?: string
+  verify?: any
 }


### PR DESCRIPTION
Custom headers are [deprecated](https://tools.ietf.org/html/rfc6648) (also read this [issue](https://github.com/graphcool/graphql-yoga/issues/303)).

This is not a breaking change, a header will still work but now the docs show the usage with the query param `?deduplicate` instead.

As a side note: I ran the script `format` and some code that's not related to this change was modified according to Prettier rules