### PR TITLE
Update Graphql-Tools Dependency to v ^3.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "graphql-playground-middleware-express": "1.6.2",
     "graphql-playground-middleware-lambda": "1.6.0",
     "graphql-subscriptions": "^0.5.8",
-    "graphql-tools": "^2.23.1",
+    "graphql-tools": "^3.0.1",
     "subscriptions-transport-ws": "^0.9.8"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1871,6 +1871,16 @@ graphql-tools@^2.23.1:
     iterall "^1.1.3"
     uuid "^3.1.0"
 
+graphql-tools@^3.0.1:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/graphql-tools/-/graphql-tools-3.0.2.tgz#fb79821c23b0f5d11d842c4d0c15000d856c6c8c"
+  dependencies:
+    apollo-link "1.2.1"
+    apollo-utilities "^1.0.1"
+    deprecated-decorator "^0.1.6"
+    iterall "^1.1.3"
+    uuid "^3.1.0"
+
 "graphql@^0.11.0 || ^0.12.0 || ^0.13.0":
   version "0.13.2"
   resolved "https://registry.yarnpkg.com/graphql/-/graphql-0.13.2.tgz#4c740ae3c222823e7004096f832e7b93b2108270"


### PR DESCRIPTION
Typescript support in `prisma-binding` requires `graphql-tools@^3.0.1` to be installed. 

`Yoga` lists `graphql-tools@^2.23.1` as a dependency. 

For whatever reason, when both `prisma-binding` and `graphql-yoga` are listed  as dependencies in `package.json,` `yarn` installs `graphql-tools@^2.23.1`, breaking typescript support in `prisma-binding`. Interestingly, `npm` (v5.8) installs `graphql-tools@^3.0.1` and everything appears to work fine, but `npm` (v6+) appears to have the same behavior as `yarn`.

Updating `yoga` to depend on `graphql-tools@^3.0.1`, resolves the issue. 

_See also_ https://github.com/prismagraphql/prisma-binding/issues/166