### PR TITLE
Fix missing required resolvers argument in mocks example. Closes #330

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ See the original documentation in [`graphql-subscriptions`](https://github.com/a
 
 #### `mocking`
 
-Mocking the schema is straight forward, along wit
+Mocking the schema is straight forward, along with
 ```javascript
 import { GraphqlServer, MockList } from 'graphql-yoga';
 
@@ -185,7 +185,7 @@ const mocks = {
 
 }
 
-const server = new GraphQLServer({ typeDefs, mocks })
+const server = new GraphQLServer({ typeDefs, resolvers: () => true, mocks })
 ```
 
 ### Endpoints


### PR DESCRIPTION
README missing resolvers function in mocks example, which is required (at least, in current implementation of graphql-yoga).