### PR TITLE
Breaking change to do with schema stitching somewhere between 1.10.0 & 1.14.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,10 +28,12 @@
     "build": "rm -rf dist && tsc -d",
     "lint": "tslint --project tsconfig.json {src,test}/**/*.ts && prettier-check --ignore-path .gitignore {src,.}/{*.ts,*.js}",
     "format": "prettier --write --ignore-path .gitignore {src,.}/{*.ts,*.js}",
-    "test": "yarn lint && yarn build && ava",
+    "test": "yarn lint && yarn build && yarn cpx-fixtures && ava",
+    "cpx-fixtures": "cpx \"src/**/*.graphql\" dist",
+    "watch:schema": "yarn cpx-fixtures -- --watch",
     "watch:tsc": "tsc --watch",
     "watch:ava": "ava --watch",
-    "watch": "yarn build && npm-run-all --parallel watch:*"
+    "watch": "yarn test && npm-run-all --parallel watch:*"
   },
   "release": {
     "branch": "master"
@@ -68,6 +70,7 @@
     "@types/aws-lambda": "8.10.3",
     "@types/request-promise-native": "1.0.14",
     "ava": "0.25.0",
+    "cpx": "^1.5.0",
     "npm-run-all": "4.1.3",
     "prettier": "1.12.1",
     "prettier-check": "2.0.0",

--- a/src/__fixtures__/books.graphql
+++ b/src/__fixtures__/books.graphql
@@ -1,0 +1,7 @@
+type Book {
+  id: ID!
+  name: String!
+  author: Author!
+}
+
+

--- a/src/__fixtures__/books.graphql
+++ b/src/__fixtures__/books.graphql
@@ -5,3 +5,6 @@ type Book {
 }
 
 
+type Query {
+  books: [Book!]!
+}

--- a/src/__fixtures__/schema.graphql
+++ b/src/__fixtures__/schema.graphql
@@ -9,5 +9,4 @@ type Author {
 
 type Query {
   hello(name: String): String!
-  books: [Book!]!
 }

--- a/src/__fixtures__/schema.graphql
+++ b/src/__fixtures__/schema.graphql
@@ -1,0 +1,16 @@
+type Author {
+  id: ID!
+  name: String!
+  lastName: String!
+}
+
+type Book {
+  id: ID!
+  name: String!
+  author: Author!
+}
+
+type Query {
+  hello(name: String): String!
+  books: [Book!]!
+}

--- a/src/__fixtures__/schema.graphql
+++ b/src/__fixtures__/schema.graphql
@@ -1,14 +1,11 @@
+# import * from "books.graphql"
+
 type Author {
   id: ID!
   name: String!
   lastName: String!
 }
 
-type Book {
-  id: ID!
-  name: String!
-  author: Author!
-}
 
 type Query {
   hello(name: String): String!

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -10,24 +10,7 @@ async function startServer(t: TestContext & Context<any>, options?: Options) {
       .toString(36)
       .substr(2, 5)
 
-  const typeDefs = `
-    type Author {
-      id: ID!
-      name: String!
-      lastName: String!
-    }
-
-    type Book {
-      id: ID!
-      name: String!
-      author: Author!
-    }
-
-    type Query {
-      hello(name: String): String!
-      books: [Book!]!
-    }
-    `
+  const typeDefs = __dirname + '/__fixtures__/schema.graphql'
 
   const author = {
     __typename: 'Author',

--- a/yarn.lock
+++ b/yarn.lock
@@ -769,7 +769,7 @@ babel-register@^6.26.0:
     mkdirp "^0.5.1"
     source-map-support "^0.4.15"
 
-babel-runtime@^6.22.0, babel-runtime@^6.26.0:
+babel-runtime@^6.22.0, babel-runtime@^6.26.0, babel-runtime@^6.9.2:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-6.26.0.tgz#965c7058668e82b55d7bfe04ff2337bc8b5647fe"
   dependencies:
@@ -1004,7 +1004,7 @@ chalk@^2.3.0:
     escape-string-regexp "^1.0.5"
     supports-color "^4.0.0"
 
-chokidar@^1.4.2:
+chokidar@^1.4.2, chokidar@^1.6.0:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-1.7.0.tgz#798e689778151c8076b4b360e5edd28cda2bb468"
   dependencies:
@@ -1197,6 +1197,22 @@ cors@^2.8.4:
     object-assign "^4"
     vary "^1"
 
+cpx@^1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/cpx/-/cpx-1.5.0.tgz#185be018511d87270dedccc293171e37655ab88f"
+  dependencies:
+    babel-runtime "^6.9.2"
+    chokidar "^1.6.0"
+    duplexer "^0.1.1"
+    glob "^7.0.5"
+    glob2base "^0.0.12"
+    minimatch "^3.0.2"
+    mkdirp "^0.5.1"
+    resolve "^1.1.7"
+    safe-buffer "^5.0.1"
+    shell-quote "^1.6.1"
+    subarg "^1.0.0"
+
 create-error-class@^3.0.0:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/create-error-class/-/create-error-class-3.0.2.tgz#06be7abef947a3f14a30fd610671d401bca8b7b6"
@@ -1361,7 +1377,7 @@ duplexer3@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/duplexer3/-/duplexer3-0.1.4.tgz#ee01dd1cac0ed3cbc7fdbea37dc0a8f1ce002ce2"
 
-duplexer@~0.1.1:
+duplexer@^0.1.1, duplexer@~0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/duplexer/-/duplexer-0.1.1.tgz#ace6ff808c1ce66b57d1ebf97977acb02334cfc1"
 
@@ -1628,6 +1644,10 @@ find-cache-dir@^1.0.0:
     make-dir "^1.0.0"
     pkg-dir "^2.0.0"
 
+find-index@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/find-index/-/find-index-0.1.1.tgz#675d358b2ca3892d795a1ab47232f8b6e2e0dde4"
+
 find-up@^1.0.0:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/find-up/-/find-up-1.1.2.tgz#6b2e9822b1a2ce0a60ab64d610eccad53cb24d0f"
@@ -1751,6 +1771,12 @@ glob-parent@^2.0.0:
   resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-2.0.0.tgz#81383d72db054fcccf5336daa902f182f6edbb28"
   dependencies:
     is-glob "^2.0.0"
+
+glob2base@^0.0.12:
+  version "0.0.12"
+  resolved "https://registry.yarnpkg.com/glob2base/-/glob2base-0.0.12.tgz#9d419b3e28f12e83a362164a277055922c9c0d56"
+  dependencies:
+    find-index "^0.1.1"
 
 glob@^7.0.3, glob@^7.0.5, glob@^7.1.1:
   version "7.1.2"
@@ -2623,7 +2649,7 @@ minimist@0.0.8:
   version "0.0.8"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d"
 
-minimist@^1.1.3, minimist@^1.2.0:
+minimist@^1.1.0, minimist@^1.1.3, minimist@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
 
@@ -3323,6 +3349,12 @@ resolve-from@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-3.0.0.tgz#b22c7af7d9d6881bc8b6e653335eebcb0a188748"
 
+resolve@^1.1.7:
+  version "1.7.1"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.7.1.tgz#aadd656374fd298aee895bc026b8297418677fd3"
+  dependencies:
+    path-parse "^1.0.5"
+
 resolve@^1.3.2:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.5.0.tgz#1f09acce796c9a762579f31b2c1cc4c3cddf9f36"
@@ -3642,6 +3674,12 @@ strip-indent@^1.0.1:
 strip-json-comments@~2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
+
+subarg@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/subarg/-/subarg-1.0.0.tgz#f62cf17581e996b48fc965699f54c06ae268b8d2"
+  dependencies:
+    minimist "^1.1.0"
 
 subscriptions-transport-ws@^0.9.8:
   version "0.9.8"


### PR DESCRIPTION
I'm trying to update my app to use the latest yoga (from `1.10.0`) & I rely a lot on `import * from [..]` to stitch my different domains together.

It seems like there has happened _something_ in between these versions that has changed that breaks this behaviour.

Here I've done an example that shows where it breaks.

As you can see here my tests works until 7cc0154 when I start splitting up the `type Query` into several files. 

**Error message:** _`Query.books` defined in resolvers, but not in schema_

Anyone with more knowledge that knows straight-away what could have caused this or if I'm doing something crazy?

Since I made my app I can see there's a new [`modular-resolvers` example](https://github.com/prismagraphql/graphql-yoga/tree/master/examples/modular-resolvers) - maybe I should invest time in refactoring with that? (I'm doing something similar.. but didn't need a lib earlier)