### PR TITLE
fix: allow Context and args typing

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -25,12 +25,12 @@ export interface IResolvers {
 }
 
 export type IResolverObject = {
-  [key: string]: GraphQLFieldResolver<any, any> | IResolverOptions
+  [key: string]: GraphQLFieldResolver<any, any, any> | IResolverOptions
 }
 
 export interface IResolverOptions {
-  resolve?: GraphQLFieldResolver<any, any>
-  subscribe?: GraphQLFieldResolver<any, any>
+  resolve?: GraphQLFieldResolver<any, any, any>
+  subscribe?: GraphQLFieldResolver<any, any, any>
   __resolveType?: GraphQLTypeResolver<any, any>
   __isTypeOf?: GraphQLIsTypeOfFn<any, any>
 }
@@ -70,7 +70,7 @@ export interface ApolloServerOptions {
   logFunction?: LogFunction
   rootValue?: any
   validationRules?: ValidationRules | ValidationRulesExpressCallback
-  fieldResolver?: GraphQLFieldResolver<any, any>
+  fieldResolver?: GraphQLFieldResolver<any, any, any>
   formatParams?: Function
   formatResponse?: Function
   debug?: boolean

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,13 +1,16 @@
-import { Request, Response } from 'express'
+import { LogFunction } from 'apollo-server-core'
 import { CorsOptions } from 'cors'
+import { Request, Response } from 'express'
 import {
-  GraphQLSchema,
   GraphQLFieldResolver,
-  GraphQLScalarType,
   GraphQLIsTypeOfFn,
+  GraphQLScalarType,
+  GraphQLSchema,
   GraphQLTypeResolver,
   ValidationContext,
 } from 'graphql'
+import { IMiddleware as IFieldMiddleware } from 'graphql-middleware'
+import { IMocks } from 'graphql-tools'
 import {
   IDirectiveResolvers,
   IResolverValidationOptions,
@@ -15,24 +18,23 @@ import {
 } from 'graphql-tools/dist/Interfaces'
 import { SchemaDirectiveVisitor } from 'graphql-tools/dist/schemaVisitor'
 import { ExecutionParams } from 'subscriptions-transport-ws'
-import { LogFunction } from 'apollo-server-core'
-import { IMocks } from 'graphql-tools'
-import { IMiddleware as IFieldMiddleware } from 'graphql-middleware'
 
 export type Omit<T, K> = Pick<T, Exclude<keyof T, K>>
-export interface IResolvers {
-  [key: string]: (() => any) | IResolverObject | GraphQLScalarType
+export interface IResolvers<Context> {
+  [key: string]: (() => any) | IResolverObject<Context> | GraphQLScalarType
 }
 
-export type IResolverObject = {
-  [key: string]: GraphQLFieldResolver<any, any, any> | IResolverOptions
+export type IResolverObject<Context> = {
+  [key: string]:
+    | GraphQLFieldResolver<any, Context, any>
+    | IResolverOptions<any, Context, any>
 }
 
-export interface IResolverOptions {
-  resolve?: GraphQLFieldResolver<any, any, any>
-  subscribe?: GraphQLFieldResolver<any, any, any>
-  __resolveType?: GraphQLTypeResolver<any, any>
-  __isTypeOf?: GraphQLIsTypeOfFn<any, any>
+export interface IResolverOptions<Source, Context, Args> {
+  resolve?: GraphQLFieldResolver<Source, Context, Args>
+  subscribe?: GraphQLFieldResolver<Source, Context, Args>
+  __resolveType?: GraphQLTypeResolver<Source, Context>
+  __isTypeOf?: GraphQLIsTypeOfFn<Source, Context>
 }
 
 export type Context = { [key: string]: any }


### PR DESCRIPTION
## Typing Args

Motivating example:

(Note `Schema.SignupMutationArgs`)

```ts
import * as GQLImport from "graphql-import"
import * as Yoga from "graphql-yoga"
import * as YogaTypes from "graphql-yoga/dist/types"
import * as Schema from "./SchemaTypes"

const typeDefs = GQLImport.importSchema(__dirname + "/TypeDefs/Main.graphql")

const resolvers: YogaTypes.IResolvers = {
  Mutation: {
    signup: (source: any, args: Schema.SignupMutationArgs, ctx, info) => {
      console.log(args)
      return ""
    },
  },
}

const server = new Yoga.GraphQLServer({ typeDefs, resolvers })

server.start().then(server => {
  console.log("started server at %s", JSON.stringify(server.address()))
})
```

```
source/Main.ts(8,7): error TS2322: Type '{ Mutation: { signup: (_: any, args: SignupMutationArgs) => string; }; }' is not assignable to type 'IResolvers'.
  Property 'Mutation' is incompatible with index signature.
    Type '{ signup: (_: any, args: SignupMutationArgs) => string; }' is not assignable to type '(() => any) | IResolverObject | GraphQLScalarType'.
      Type '{ signup: (_: any, args: SignupMutationArgs) => string; }' is not assignable to type 'GraphQLScalarType'.
        Property 'name' is missing in type '{ signup: (_: any, args: SignupMutationArgs) => string; }'.
```

This PR fixes the above TS error.

The reason for `any` and not just `Record<string,any>` is that we're apparently (surprisingly...) hitting a TS bug:

* https://stackoverflow.com/questions/46361905/property-is-missing-in-type-x-string-string
* https://github.com/Microsoft/TypeScript/issues/13948

If I reduce the union type in Yoga to get at the error (the error message above hits the scaler case because the first two failed, hiding the error message we're interested in):

```
TSError: ⨯ Unable to compile TypeScript:
source/Main.ts(8,7): error TS2322: Type '{ Mutation: { signup: (_: any, args: SignupMutationArgs) => string; }; }' is not assignable to type 'IResolvers'.
  Property 'Mutation' is incompatible with index signature.
    Type '{ signup: (_: any, args: SignupMutationArgs) => string; }' is not assignable to type 'IResolverObject'.
      Property 'signup' is incompatible with index signature.
        Type '(_: any, args: SignupMutationArgs) => string' is not assignable to type 'GraphQLFieldResolver<any, any, { [argName: string]: any; }>'.
          Types of parameters 'args' and 'args' are incompatible.
            Type '{ [argName: string]: any; }' is not assignable to type 'SignupMutationArgs'.
              Property 'email' is missing in type '{ [argName: string]: any; }'.
```

IIUC `              Property 'email' is missing in type '{ [argName: string]: any; }'.` makes no sense because `{ [argName: string]: any; }` should encompass the possibility for any `string` key name :('

So alas I am using `any`. Luckily it actually does not seem to matter for the developer as she only really cares at the time of resolver implementation and the Any we're putting here can be overridden as shown in my motivating example.

## Typing Context

Motivating example:

```ts
// Context.ts
import * as Core from "./Schema/Remotes/Core"

type Context = {
  core: Core.Prisma
}

let coreClient: Core.Prisma

const create = () => {
  if (coreClient === undefined) {
    coreClient = new Core.Prisma({
      endpoint: "http://localhost:4466/core/dev",
    })
  }
  return {
    core: coreClient,
  }
}

export { create, Context }

```

```ts
import * as GQLImport from "graphql-import"
import * as Yoga from "graphql-yoga"
import * as YogaTypes from "graphql-yoga/dist/types"
import * as Context from "./Context"

type Resolvers = YogaTypes.IResolvers<Context.Context>

const resolvers: Resolvers = {
  Mutation: {
    signup: (_, args, ctx, info) => {
      return ctx.core.query.users(args, info)
    },
  },
}

// ...
```
