### PR TITLE
feat: Pass down messages to context builder on onOperation executions

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -400,7 +400,7 @@ export class GraphQLServer {
           try {
             context =
               typeof this.context === 'function'
-                ? await this.context({ connection })
+                ? await this.context({ connection, message })
                 : this.context
           } catch (e) {
             console.error(e)


### PR DESCRIPTION
This allows to work with custom params when resolving the operations.

Since we can't define custom `onOperation` handlers, this will at least let us manipulate the message and its params to set our contexts accordingly.