### PR TITLE
Add webSocket object to subscription context function (fixes #393)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -399,7 +399,7 @@ export class GraphQLServer {
           try {
             context =
               typeof this.context === 'function'
-                ? await this.context({ connection })
+                ? await this.context({ connection, webSocket })
                 : this.context
           } catch (e) {
             console.error(e)


### PR DESCRIPTION
The subscription context callback function is only receiving the `connection` object but missing the `webSocket` object containing the WebSocket Upgrade Request.