### PR TITLE
add expressApp option to GraphQLServer constructor args

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -85,7 +85,7 @@ export class GraphQLServer {
   } = { use: [], get: [], post: [] }
 
   constructor(props: Props) {
-    this.express = express()
+    this.express = props.expressApp || express();
 
     this.subscriptionServer = null
     this.context = props.context

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-import { Request, Response } from 'express'
+import { Request, Response, Express } from 'express'
 import { CorsOptions } from 'cors'
 import {
   GraphQLSchema,
@@ -127,6 +127,7 @@ export interface Props<
     TFieldMiddlewareContext,
     TFieldMiddlewareArgs
   >[]
+  expressApp?: Express
 }
 
 export interface LambdaProps<


### PR DESCRIPTION
## Why: currently, graphql-yoga forces itself to be a 'root-express-app'.
 - there's an option to eject, but I don't want to.
 - ejecting means not getting more updates from graphql-yoga (no more goodies :( )

## what: this commit enables graphql-yoga to be a 'last-loaded' express endpoint:

```
const expressApp = new Express();
initHelmetMiddleware({ 
  expressApp,
  // ...
});
initSocketIOEndpoint({
  expressApp,
  // ...
})
initGraphqlEndpoint({ // internally creates GraphqlServer 
  expressApp,
  // ...
})

// somewhere
function initGraphqlEndpoint( { expressApp } ) {
  const graphqlServer = new GraphqlServer({ expressApp, ... })
}
```

thank you for your consideration!