### PR TITLE
fix: Update lambda type signatures

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -15,6 +15,7 @@ import {
   IMiddlewareGenerator as IFieldMiddlewareGenerator,
   FragmentReplacement,
 } from 'graphql-middleware'
+import { APIGatewayProxyEvent, Context as LambdaContext } from 'aws-lambda'
 
 export type Omit<T, K> = Pick<T, Exclude<keyof T, K>>
 
@@ -27,7 +28,14 @@ export interface ContextParameters {
   fragmentReplacements: FragmentReplacement[]
 }
 
+export interface LambdaContextParameters {
+  event: APIGatewayProxyEvent
+  context: LambdaContext
+}
+
 export type ContextCallback = (params: ContextParameters) => Context
+
+export type LambdaContextCallback = (params: LambdaContextParameters) => Context
 
 // check https://github.com/jaydenseric/apollo-upload-server#options for documentation
 export interface UploadOptions {
@@ -132,7 +140,7 @@ export interface LambdaProps<
   resolvers?: IResolvers
   resolverValidationOptions?: IResolverValidationOptions
   schema?: GraphQLSchema
-  context?: Context | ContextCallback
+  context?: Context | LambdaContextCallback
   options?: LambdaOptions
   middlewares?: (
     | IFieldMiddleware<


### PR DESCRIPTION
Lambda context isn't called with the same parameters as the express version:

https://github.com/prismagraphql/graphql-yoga/blob/e73f9b68a405e43d5260c8068b3d3244a4d00730/src/lambda.ts#L116

vs

https://github.com/prismagraphql/graphql-yoga/blob/e73f9b68a405e43d5260c8068b3d3244a4d00730/src/index.ts#L254