### PR TITLE
Allow user to pass in an existing express instance if desired

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -90,7 +90,7 @@ export class GraphQLServer {
   } = { use: [], get: [], post: [] }
 
   constructor(props: Props) {
-    this.express = express()
+    this.express = props.express || express()
 
     this.subscriptionServer = null
     this.context = props.context

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-import { Request, Response } from 'express'
+import { Request, Response, Application } from 'express'
 import { CorsOptions } from 'cors'
 import {
   GraphQLSchema,
@@ -112,6 +112,7 @@ export interface Props<
   TFieldMiddlewareContext = any,
   TFieldMiddlewareArgs = any
 > {
+  express?: Application
   directiveResolvers?: IDirectiveResolvers<any, any>
   schemaDirectives?: {
     [name: string]: typeof SchemaDirectiveVisitor


### PR DESCRIPTION
To make it easier to use graphql-yoga with other frameworks such as nestjs and routing-controllers. 