### PR TITLE
allow resolvers to be an array of resolvers

### DIFF
--- a/examples/modular-resolvers/index.ts
+++ b/examples/modular-resolvers/index.ts
@@ -1,14 +1,16 @@
-import { GraphQLServer } from "graphql-yoga";
+import { GraphQLServer } from 'graphql-yoga'
 import { default as typeDefs } from './typeDefs'
 import { default as resolvers } from './resolvers'
 
-const options = { port: 4004 };
+const options = { port: 4004 }
 
 const server = new GraphQLServer({
   typeDefs,
-  resolvers
-});
+  resolvers,
+})
 
-server.start(options, () =>
-  console.log(`Server is running ⚡ on localhost:${options.port}`))
-  .catch(err => console.error('connection Error', err));
+server
+  .start(options, () =>
+    console.log(`Server is running ⚡ on localhost:${options.port}`),
+  )
+  .catch(err => console.error('connection Error', err))

--- a/examples/modular-resolvers/resolvers/index.ts
+++ b/examples/modular-resolvers/resolvers/index.ts
@@ -1,5 +1,5 @@
-import * as path from "path";
-import { mergeResolvers, fileLoader } from "merge-graphql-schemas";
+import * as path from 'path'
+import { fileLoader } from 'merge-graphql-schemas'
 
 /* MANUAL APPROACH: Update this file manually with each resolver file */
 // import userResolvers from "./user.resolvers";
@@ -8,8 +8,6 @@ import { mergeResolvers, fileLoader } from "merge-graphql-schemas";
 
 /*  AUTOMATED APPROACH: Put your resolvers anywhere 
     with ".resolvers.[js/ts]" naming convention */
-const resolversArray = fileLoader(path.join(__dirname, "./**/*.resolvers.*"));
+const resolvers = fileLoader(path.join(__dirname, './**/*.resolvers.*'))
 
-const resolvers = mergeResolvers(resolversArray);
-
-export default resolvers;
+export default resolvers

--- a/src/index.ts
+++ b/src/index.ts
@@ -117,10 +117,10 @@ export class GraphQLServer {
         directiveResolvers,
         schemaDirectives,
         typeDefs: typeDefsString,
-        resolvers: {
-          ...uploadMixin,
-          ...resolvers,
-        },
+        resolvers: Array.isArray(resolvers)
+          ? [uploadMixin, ...resolvers]
+          : [uploadMixin, resolvers],
+
         resolverValidationOptions,
       })
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -122,7 +122,7 @@ export interface Props<
     [name: string]: typeof SchemaDirectiveVisitor
   }
   typeDefs?: ITypeDefinitions
-  resolvers?: IResolvers
+  resolvers?: IResolvers | IResolvers[]
   resolverValidationOptions?: IResolverValidationOptions
   schema?: GraphQLSchema
   context?: Context | ContextCallback


### PR DESCRIPTION
this is already supported by `makeExecutableSchema`, so no additional implementation was necessary.

I've also updated the associated example accordingly