### PR TITLE
Types don't match docs & usage

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -126,7 +126,7 @@ export interface Props<
   resolverValidationOptions?: IResolverValidationOptions
   schema?: GraphQLSchema
   context?: Context | ContextCallback
-  mocks?: IMocks
+  mocks?: IMocks | boolean
   middlewares?: (
     | IFieldMiddleware<
         TFieldMiddlewareSource,


### PR DESCRIPTION
The docs specify `mocks` can be a list of mocks or `true`, and the code bears this out, but the types only allow `IMocks` or nothing.