### PR TITLE
upgrade graphql-deduplicator

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "cors": "^2.8.4",
     "express": "^4.16.3",
     "graphql": "^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0",
-    "graphql-deduplicator": "^2.0.1",
+    "graphql-deduplicator": "^2.0.2",
     "graphql-import": "^0.7.0",
     "graphql-middleware": "1.7.7",
     "graphql-playground-middleware-express": "1.7.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1772,9 +1772,9 @@ graphql-config@2.2.1:
     lodash "^4.17.4"
     minimatch "^3.0.4"
 
-graphql-deduplicator@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/graphql-deduplicator/-/graphql-deduplicator-2.0.1.tgz#20c6b39e3a6f096b46dfc8491432818739c0ee37"
+graphql-deduplicator@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/graphql-deduplicator/-/graphql-deduplicator-2.0.2.tgz#d8608161cf6be97725e178df0c41f6a1f9f778f3"
 
 graphql-extensions@^0.0.x:
   version "0.0.5"


### PR DESCRIPTION
Upgrades `graphql-deduplicator` to `2.0.2` to take a bug fix.

https://github.com/gajus/graphql-deduplicator/releases/tag/v2.0.2