### PR TITLE
@types/aws-lambda is a dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "files": ["dist/**/*.test.js"]
   },
   "dependencies": {
+    "@types/aws-lambda": "8.10.13",
     "@types/cors": "^2.8.4",
     "@types/express": "^4.11.1",
     "@types/graphql": "^14.0.0",
@@ -57,7 +58,6 @@
     "subscriptions-transport-ws": "^0.9.8"
   },
   "devDependencies": {
-    "@types/aws-lambda": "8.10.13",
     "@types/request-promise-native": "1.0.15",
     "ava": "0.25.0",
     "npm-run-all": "4.1.3",


### PR DESCRIPTION
https://github.com/prisma/graphql-yoga/blob/master/src/types.ts#L18 requires @types/aws-lambda. And when using graphql-yoga in a TypeScript "native" project, this produces errors:

```
$ yarn tsc --noEmit
yarn run v1.10.1
$ /Users/skainswo/dev/kumo/node-api/node_modules/.bin/tsc --noEmit
node_modules/graphql-yoga/dist/types.d.ts:11:64 - error TS7016: Could not find a declaration file for module 'aws-lambda'. '/Users/skainswo/dev/kumo/node-api/node_modules/aws-lambda/lib/main.js' implicitly has an 'any' type.
  Try `npm install @types/aws-lambda` if it exists or add a new declaration (.d.ts) file containing `declare module 'aws-lambda';`

11 import { APIGatewayProxyEvent, Context as LambdaContext } from 'aws-lambda';
                                                                  ~~~~~~~~~~~~
```
