### PR TITLE
Replace stream with createReadStream() in example

### DIFF
--- a/examples/file-upload/index.ts
+++ b/examples/file-upload/index.ts
@@ -34,7 +34,8 @@ const recordFile = file =>
     .write()
 
 const processUpload = async upload => {
-  const { stream, filename, mimetype, encoding } = await upload
+  const { createReadStream, filename, mimetype, encoding } = await upload
+  const stream = createReadStream();
   const { id, path } = await storeUpload({ stream, filename })
   return recordFile({ id, filename, mimetype, encoding, path })
 }


### PR DESCRIPTION
Since v7.0.0 https://github.com/jaydenseric/graphql-upload/commit/a6a6769d3c5daddd36554c316f911925276072e5, accessing an Upload scalar promise resolved stream property results in a deprecation warning that recommends using createReadStream instead. It will be removed in a future release. Via #107.

And hence shouldn't be encouraged in an example.