### PR TITLE
add createExpressApplication method to GraphQLServer and use it internally

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -164,9 +164,7 @@ export class GraphQLServer {
     return this
   }
 
-  createHttpServer(options: OptionsWithoutHttps): HttpServer
-  createHttpServer(options: OptionsWithHttps): HttpsServer
-  createHttpServer(options: Options): HttpServer | HttpsServer {
+  createExpressApplication(options: Options): express.Application {
     const app = this.express
 
     this.options = { ...this.options, ...options }
@@ -349,6 +347,13 @@ export class GraphQLServer {
       throw new Error('No schema defined')
     }
 
+    return app
+  }
+
+  createHttpServer(options: OptionsWithoutHttps): HttpServer
+  createHttpServer(options: OptionsWithHttps): HttpsServer
+  createHttpServer(options: Options): HttpServer | HttpsServer {
+    const app = this.createExpressApplication(options)
     const server = this.options.https
       ? createHttpsServer(this.options.https, app)
       : createServer(app)


### PR DESCRIPTION
This solves #537

After this being implemented my code to run a Now v2 Lambda with graphql-yoga is like this:

```typescript
const server = new GraphQLServer({
  typeDefs: __dirname + "/schema_prep.graphql", // now v2 will break graphql-import syntax, you have to preproccess it and import it using __dirname in the path
  resolvers: resolvers,
  context: makeContext,
});

module.exports = server.createExpressApplication({
  endpoint: "/api/",
  subscriptions: false,
  playground: "/api/",
});
```