### PR TITLE
fix(deps): move from apollo-upload-server to graphql-upload

### DIFF
--- a/examples/file-upload/README.md
+++ b/examples/file-upload/README.md
@@ -20,4 +20,6 @@ yarn start   # or npm start
 
 ## Using the file-upload api
 
-The graphql-yoga server uses [apollo-upload-server](https://github.com/jaydenseric/apollo-upload-server) to handle file uploads. It expects files to be uploaded through a specific [GraphQL multi-part request](https://github.com/jaydenseric/graphql-multipart-request-spec). The simplest way to correctly handle the outgoing request is to use [apollo-upload-client](https://github.com/jaydenseric/apollo-upload-client). See [apollo-upload-examples](https://github.com/jaydenseric/apollo-upload-examples) for a react client uploading to apollo-upload-server similar in function to the one here.
+The graphql-yoga server uses [graphql-upload](https://github.com/jaydenseric/graphql-upload) to handle file uploads. It expects files to be uploaded through a specific [GraphQL multi-part request](https://github.com/jaydenseric/graphql-multipart-request-spec). The simplest way to correctly handle the outgoing request is to use [apollo-upload-client](https://github.com/jaydenseric/apollo-upload-client). See [apollo-upload-examples](https://github.com/jaydenseric/apollo-upload-examples) for a react client uploading to apollo-upload-server similar in function to the one here.
+
+N.B. apollo-upload-server is the old package name for graphql-upload.

--- a/package.json
+++ b/package.json
@@ -4,12 +4,20 @@
   "version": "0.0.0-semantic-release",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "repository": {
     "type": "git",
     "url": "git+https://github.com/prisma/graphql-yoga.git"
   },
-  "keywords": ["graphql", "server", "api", "graphql-server", "apollo"],
+  "keywords": [
+    "graphql",
+    "server",
+    "api",
+    "graphql-server",
+    "apollo"
+  ],
   "author": "Johannes Schickling <johannes@graph.cool>",
   "license": "MIT",
   "bugs": {
@@ -19,8 +27,7 @@
   "scripts": {
     "prepublish": "yarn build",
     "build": "rm -rf dist && tsc -d",
-    "lint":
-      "tslint --project tsconfig.json {src,test}/**/*.ts && prettier-check --ignore-path .gitignore {src,.}/{*.ts,*.js}",
+    "lint": "tslint --project tsconfig.json {src,test}/**/*.ts && prettier-check --ignore-path .gitignore {src,.}/{*.ts,*.js}",
     "format": "prettier --write --ignore-path .gitignore {src,.}/{*.ts,*.js}",
     "test": "yarn lint && yarn build && ava",
     "watch:tsc": "tsc --watch",
@@ -31,7 +38,9 @@
     "branch": "master"
   },
   "ava": {
-    "files": ["dist/**/*.test.js"]
+    "files": [
+      "dist/**/*.test.js"
+    ]
   },
   "dependencies": {
     "@types/cors": "^2.8.4",
@@ -41,7 +50,6 @@
     "@types/zen-observable": "^0.5.3",
     "apollo-server-express": "^1.3.6",
     "apollo-server-lambda": "1.3.6",
-    "apollo-upload-server": "^7.0.0",
     "aws-lambda": "^0.1.2",
     "body-parser-graphql": "1.1.0",
     "cors": "^2.8.4",
@@ -54,6 +62,7 @@
     "graphql-playground-middleware-lambda": "1.7.12",
     "graphql-subscriptions": "^0.5.8",
     "graphql-tools": "^4.0.0",
+    "graphql-upload": "^8.0.4",
     "subscriptions-transport-ws": "^0.9.8"
   },
   "devDependencies": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 import { graphqlExpress } from 'apollo-server-express'
-import { apolloUploadExpress, GraphQLUpload } from 'apollo-upload-server'
+import { graphqlUploadExpress, GraphQLUpload } from 'graphql-upload'
 import * as bodyParser from 'body-parser-graphql'
 import * as cors from 'cors'
 import * as express from 'express'
@@ -221,9 +221,12 @@ export class GraphQLServer {
     )
 
     if (this.options.uploads) {
-      app.post(this.options.endpoint, apolloUploadExpress(this.options.uploads))
+      app.post(
+        this.options.endpoint,
+        graphqlUploadExpress(this.options.uploads),
+      )
     } else if (this.options.uploads !== false) {
-      app.post(this.options.endpoint, apolloUploadExpress())
+      app.post(this.options.endpoint, graphqlUploadExpress())
     }
 
     // All middlewares added before start() was called are applied to

--- a/src/types.ts
+++ b/src/types.ts
@@ -37,7 +37,7 @@ export type ContextCallback = (params: ContextParameters) => Context
 
 export type LambdaContextCallback = (params: LambdaContextParameters) => Context
 
-// check https://github.com/jaydenseric/apollo-upload-server#options for documentation
+// check https://github.com/jaydenseric/graphql-upload#api for documentation
 export interface UploadOptions {
   maxFieldSize?: number
   maxFileSize?: number

--- a/yarn.lock
+++ b/yarn.lock
@@ -258,15 +258,6 @@ apollo-tracing@^0.1.0:
   dependencies:
     graphql-extensions "^0.0.x"
 
-apollo-upload-server@^7.0.0:
-  version "7.1.0"
-  resolved "https://registry.yarnpkg.com/apollo-upload-server/-/apollo-upload-server-7.1.0.tgz#21e07b52252b3749b913468599813e13cfca805f"
-  dependencies:
-    busboy "^0.2.14"
-    fs-capacitor "^1.0.0"
-    http-errors "^1.7.0"
-    object-path "^0.11.4"
-
 apollo-utilities@^1.0.0, apollo-utilities@^1.0.1:
   version "1.0.11"
   resolved "https://registry.yarnpkg.com/apollo-utilities/-/apollo-utilities-1.0.11.tgz#cd36bfa6e5c04eea2caf0c204a0f38a0ad550802"
@@ -880,12 +871,12 @@ builtin-modules@^1.0.0, builtin-modules@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/builtin-modules/-/builtin-modules-1.1.1.tgz#270f076c5a72c02f5b65a47df94c5fe3a278892f"
 
-busboy@^0.2.14:
-  version "0.2.14"
-  resolved "https://registry.yarnpkg.com/busboy/-/busboy-0.2.14.tgz#6c2a622efcf47c57bbbe1e2a9c37ad36c7925453"
+busboy@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/busboy/-/busboy-0.3.0.tgz#6ee3cb1c844fc1f691d8f9d824f70128b3b5e485"
+  integrity sha512-e+kzZRAbbvJPLjQz2z+zAyr78BSi9IFeBTyLwF76g78Q2zRt/RZ1NtS3MS17v2yLqYfLz69zHdC+1L4ja8PwqQ==
   dependencies:
-    dicer "0.2.5"
-    readable-stream "1.1.x"
+    dicer "0.3.0"
 
 bytes@3.0.0:
   version "3.0.0"
@@ -1277,11 +1268,11 @@ detect-libc@^1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-1.0.3.tgz#fa137c4bd698edf55cd5cd02ac559f91a4c4ba9b"
 
-dicer@0.2.5:
-  version "0.2.5"
-  resolved "https://registry.yarnpkg.com/dicer/-/dicer-0.2.5.tgz#5996c086bb33218c812c090bddc09cd12facb70f"
+dicer@0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/dicer/-/dicer-0.3.0.tgz#eacd98b3bfbf92e8ab5c2fdb71aaac44bb06b872"
+  integrity sha512-MdceRRWqltEG2dZqO769g27N/3PXfcKl04VhYnBlo2YhH7zPi88VebsjTKclaOyiuMaGU72hTfw3VkUitGcVCA==
   dependencies:
-    readable-stream "1.1.x"
     streamsearch "0.1.2"
 
 diff@^3.2.0:
@@ -1625,9 +1616,10 @@ from@~0:
   version "0.1.7"
   resolved "https://registry.yarnpkg.com/from/-/from-0.1.7.tgz#83c60afc58b9c56997007ed1a768b3ab303a44fe"
 
-fs-capacitor@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/fs-capacitor/-/fs-capacitor-1.0.1.tgz#ff9dbfa14dfaf4472537720f19c3088ed9278df0"
+fs-capacitor@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/fs-capacitor/-/fs-capacitor-2.0.1.tgz#8b27ce79979a4ed2427e7bb6bf3d781344f7ea56"
+  integrity sha512-kyV2oaG1/pu9NPosfGACmBym6okgzyg6hEtA5LSUq0dGpGLe278MVfMwVnSHDA/OBcTCHkPNqWL9eIwbPN6dDg==
 
 fs-minipass@^1.2.5:
   version "1.2.5"
@@ -1815,6 +1807,16 @@ graphql-tools@^4.0.4:
     iterall "^1.1.3"
     uuid "^3.1.0"
 
+graphql-upload@^8.0.4:
+  version "8.0.4"
+  resolved "https://registry.yarnpkg.com/graphql-upload/-/graphql-upload-8.0.4.tgz#ed7cbde883b5cca493de77e39f95cddf40dfd514"
+  integrity sha512-jsTfVYXJ5mU6BXiiJ20CUCAcf41ICCQJ2ltwQFUuaFKiY4JhlG99uZZp5S3hbpQ/oA1kS7hz4pRtsnxPCa7Yfg==
+  dependencies:
+    busboy "^0.3.0"
+    fs-capacitor "^2.0.0"
+    http-errors "^1.7.1"
+    object-path "^0.11.4"
+
 "graphql@^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0":
   version "14.0.2"
   resolved "https://registry.yarnpkg.com/graphql/-/graphql-14.0.2.tgz#7dded337a4c3fd2d075692323384034b357f5650"
@@ -1884,13 +1886,14 @@ http-errors@1.6.2, http-errors@~1.6.2:
     setprototypeof "1.0.3"
     statuses ">= 1.3.1 < 2"
 
-http-errors@^1.7.0:
-  version "1.7.1"
-  resolved "https://registry.yarnpkg.com/http-errors/-/http-errors-1.7.1.tgz#6a4ffe5d35188e1c39f872534690585852e1f027"
+http-errors@^1.7.1:
+  version "1.7.2"
+  resolved "https://registry.yarnpkg.com/http-errors/-/http-errors-1.7.2.tgz#4f5029cf13239f31036e5b2e55292bcfbcc85c8f"
+  integrity sha512-uUQBt3H/cSIVfch6i1EuPNy/YsRSOUBXTVfZ+yR7Zjez3qjBz6i9+i4zjNaoqcoFVI4lQJ5plg63TvGfRSDCRg==
   dependencies:
     depd "~1.1.2"
     inherits "2.0.3"
-    setprototypeof "1.1.0"
+    setprototypeof "1.1.1"
     statuses ">= 1.5.0 < 2"
     toidentifier "1.0.0"
 
@@ -1977,7 +1980,7 @@ inflight@^1.0.4:
     once "^1.3.0"
     wrappy "1"
 
-inherits@2, inherits@2.0.3, inherits@^2.0.1, inherits@~2.0.1, inherits@~2.0.3:
+inherits@2, inherits@2.0.3, inherits@^2.0.1, inherits@~2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
 
@@ -2698,6 +2701,7 @@ object-keys@^1.0.8:
 object-path@^0.11.4:
   version "0.11.4"
   resolved "https://registry.yarnpkg.com/object-path/-/object-path-0.11.4.tgz#370ae752fbf37de3ea70a861c23bba8915691949"
+  integrity sha1-NwrnUvvzfePqcKhhwju6iRVpGUk=
 
 object.omit@^2.0.0:
   version "2.0.1"
@@ -3082,15 +3086,6 @@ read-pkg@^3.0.0:
     normalize-package-data "^2.3.2"
     path-type "^3.0.0"
 
-readable-stream@1.1.x:
-  version "1.1.14"
-  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-1.1.14.tgz#7cf4c54ef648e3813084c636dd2079e166c081d9"
-  dependencies:
-    core-util-is "~1.0.0"
-    inherits "~2.0.1"
-    isarray "0.0.1"
-    string_decoder "~0.10.x"
-
 readable-stream@^2.0.2, readable-stream@^2.0.6, readable-stream@^2.1.5:
   version "2.3.6"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.6.tgz#b11c27d88b8ff1fbe070643cf94b0c79ae1b0aaf"
@@ -3345,6 +3340,11 @@ setprototypeof@1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/setprototypeof/-/setprototypeof-1.1.0.tgz#d0bd85536887b6fe7c0d818cb962d9d91c54e656"
 
+setprototypeof@1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/setprototypeof/-/setprototypeof-1.1.1.tgz#7e95acb24aa92f5885e0abef5ba131330d4ae683"
+  integrity sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw==
+
 shebang-command@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/shebang-command/-/shebang-command-1.2.0.tgz#44aac65b695b03398968c39f363fee5deafdf1ea"
@@ -3465,6 +3465,7 @@ stack-utils@^1.0.1:
 "statuses@>= 1.5.0 < 2":
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/statuses/-/statuses-1.5.0.tgz#161c7dac177659fd9811f43771fa99381478628c"
+  integrity sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=
 
 stealthy-require@^1.1.0:
   version "1.1.1"
@@ -3479,6 +3480,7 @@ stream-combiner@~0.0.4:
 streamsearch@0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/streamsearch/-/streamsearch-0.1.2.tgz#808b9d0e56fc273d809ba57338e929919a1a9f1a"
+  integrity sha1-gIudDlb8Jz2Am6VzOOkpkZoanxo=
 
 string-width@^1.0.1, string-width@^1.0.2:
   version "1.0.2"
@@ -3502,10 +3504,6 @@ string.prototype.padend@^3.0.0:
     define-properties "^1.1.2"
     es-abstract "^1.4.3"
     function-bind "^1.0.2"
-
-string_decoder@~0.10.x:
-  version "0.10.31"
-  resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-0.10.31.tgz#62e203bc41766c6c28c9fc84301dab1c5310fa94"
 
 string_decoder@~1.1.1:
   version "1.1.1"
@@ -3658,6 +3656,7 @@ to-fast-properties@^1.0.3:
 toidentifier@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/toidentifier/-/toidentifier-1.0.0.tgz#7e1be3470f1e77948bc43d94a3c8f4d7752ba553"
+  integrity sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw==
 
 tough-cookie@>=2.3.3:
   version "2.3.4"


### PR DESCRIPTION
### What
Change the dependency on `apollo-upload-server` to `graphql-upload`, as per release-notes: https://github.com/jaydenseric/graphql-upload/blob/master/changelog.md#800

### Why
To fix the deprecation warning from `apollo-upload-server` when installing this module.

### Related Issues
Fixes #501 

### Notes
There's some package.json formatting changes. I believe this is from me running the prettier script locally.

Also not sure why the checks are failing, it builds locally.