### PR TITLE
feat(express): optional express factory function

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,6 +262,12 @@ server.express.post(server.options.endpoint, myMiddleware())
 
 Any middleware you add to that route, will be added right before the `apollo-server-express` middleware.
 
+If you already have an express app that was created somewhere else, you can pass it to the GraphQLServer constructor:
+
+```js
+const server = new GraphQLServer({ getExpressApp: () => myPreExistingExpressApp })
+```
+
 ## Help & Community [![Slack Status](https://slack.prisma.io/badge.svg)](https://slack.prisma.io)
 
 Join our [Slack community](http://slack.graph.cool/) if you run into issues or have questions. We love talking to you!

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,4 +1,5 @@
 import test, { TestContext, Context } from 'ava'
+import { Express } from 'express'
 import { inflate } from 'graphql-deduplicator'
 import { GraphQLServer, Options } from './index'
 import { promisify } from 'util'
@@ -400,4 +401,12 @@ test('Works with array of resolvers', async t => {
       },
     },
   })
+})
+
+test('Allows passing in an express app function', t => {
+  const fakeExpressApp: Express = {} as any
+  const server = new GraphQLServer({
+    getExpressApp: () => fakeExpressApp,
+  })
+  t.is(server.express, fakeExpressApp)
 })

--- a/src/index.ts
+++ b/src/index.ts
@@ -90,7 +90,8 @@ export class GraphQLServer {
   } = { use: [], get: [], post: [] }
 
   constructor(props: Props) {
-    this.express = express()
+    const getExpressApp = props.getExpressApp || express
+    this.express = getExpressApp()
 
     this.subscriptionServer = null
     this.context = props.context

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-import { Request, Response } from 'express'
+import { Express, Request, Response } from 'express'
 import { CorsOptions } from 'cors'
 import { GraphQLSchema, GraphQLFieldResolver, ValidationContext } from 'graphql'
 import {
@@ -114,6 +114,7 @@ export interface Props<
   resolverValidationOptions?: IResolverValidationOptions
   schema?: GraphQLSchema
   context?: Context | ContextCallback
+  getExpressApp?: () => Express
   mocks?: IMocks | boolean
   middlewares?: (
     | IFieldMiddleware<


### PR DESCRIPTION
This allows passing in a function returning an express app, rather than relying on `express()`. This will enable passing in an existing application which could have been created elsewhere.

Fixes https://github.com/prisma/graphql-yoga/issues/309