### PR TITLE
Fix AWS dependencies - shrinks this package by 60%

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "files": ["dist/**/*.test.js"]
   },
   "dependencies": {
+    "@types/aws-lambda": "8.10.13",
     "@types/cors": "^2.8.4",
     "@types/express": "^4.11.1",
     "@types/graphql": "^14.0.0",
@@ -42,7 +43,6 @@
     "apollo-server-express": "^1.3.6",
     "apollo-server-lambda": "1.3.6",
     "apollo-upload-server": "^7.0.0",
-    "aws-lambda": "^0.1.2",
     "body-parser-graphql": "1.1.0",
     "cors": "^2.8.4",
     "express": "^4.16.3",
@@ -58,9 +58,9 @@
     "subscriptions-transport-ws": "^0.9.8"
   },
   "devDependencies": {
-    "@types/aws-lambda": "8.10.13",
     "@types/request-promise-native": "1.0.15",
     "ava": "0.25.0",
+    "aws-lambda": "^0.1.2",
     "npm-run-all": "4.1.3",
     "prettier": "1.12.1",
     "prettier-check": "2.0.0",


### PR DESCRIPTION
This package currently depends on aws-lambda, which depends on aws-sdk, which is a _massive_ package (41MB, before dependencies).

This is only used in [`types.ts`](https://github.com/prisma/graphql-yoga/blob/master/src/types.ts), which uses it only for type definitions. These don't exist at runtime (check out the empty compiled version in [`types.js`](https://unpkg.com/graphql-yoga@1.18.0/dist/types.js)), and aws-lambda is never actually used directly.

Unfortunately, aws-lambda is a production dependency of this package, and @types/aws-lambda is a development dependency, which means:

* Every user of this package has to download aws-lambda & aws-sdk, and deploy it as part of their codebase (discussed in #436, but never fixed).
* Every TypeScript user of this package has to manually install `@types/aws-lambda` for themselves to make it usable (see #485).

This PR fixes both together by swapping the dependencies around. Doing a quick local test, for me locally this reduces the installed size of this package from 72MB to 29MB, and fixes this TypeScript issue.