### PR TITLE
Updated graphql-subscriptions

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "graphql-middleware": "3.0.2",
     "graphql-playground-middleware-express": "1.7.11",
     "graphql-playground-middleware-lambda": "1.7.12",
-    "graphql-subscriptions": "^0.5.8",
+    "graphql-subscriptions": "^1.1.0",
     "graphql-tools": "^4.0.0",
     "graphql-upload": "^8.0.0",
     "subscriptions-transport-ws": "^0.9.8"


### PR DESCRIPTION
Updated graphql-subscriptions from `v0.5.8` to `v1.1.0` to remove incorrect peer dependency warning: `graphql-subscriptions@0.5.8" has incorrect peer dependency "graphql@^0.10.5 || ^0.11.3 || ^0.12.0 || ^0.13.0"`. From my research, I don’t believe the [breaking change](https://github.com/apollographql/graphql-subscriptions/releases/tag/v1.0.0) to v1.0.0 affects this package.